### PR TITLE
Warning fix [-Wreorder]. Include path correction.

### DIFF
--- a/HapcanDevice.cpp
+++ b/HapcanDevice.cpp
@@ -82,18 +82,18 @@ HapcanDevice::HapcanDevice()
 	, m_TxBufferReadIndex(0)
 	, m_rxBufferOverflowCount(0)
 	, m_txBufferOverflowCount(0)
-	, m_node(Hapcan::Config::Node::SerialNumber2)
 	, m_group(Hapcan::Config::Node::SerialNumber3)
+	, m_node(Hapcan::Config::Node::SerialNumber2)
 	, m_processOwnMessages(false)
 	, m_receiveAnswerMessages(false)
 	, m_isInProgrammingMode(false)
 	, m_isInitialized(false)
 	, m_memoryAddress(0)
 	, m_memoryCommand(Programming::Command::Undefined)
-	, m_executeInstructionDelegate(NULL)
-	, m_statusRequestDelegate(NULL)
 	, m_uptime(0UL)
 	, m_lastMillis(0UL)
+	, m_executeInstructionDelegate(NULL)
+	, m_statusRequestDelegate(NULL)
 {
 	pHapcanDevice = this;
 }
@@ -340,7 +340,7 @@ void HapcanDevice::ProcessProgrammingMessage(HapcanMessage* message)
 // Process normal message type. Checks box enable bits and test HAPCAN message conditions. 
 bool HapcanDevice::ProcessNormalMessage(HapcanMessage* message)
 {
-	unsigned int boxConfigAddress = CoreConfig::EEPROM::BoxConfigAddress;
+	//unsigned int boxConfigAddress = CoreConfig::EEPROM::BoxConfigAddress;
 	for (byte i = 0; i < CoreConfig::BoxCount/8; i++)
 	{
 		byte boxEnableFlags = EEPROM[CoreConfig::EEPROM::BoxEnableAddress + i];

--- a/SubModules/HapcanRelay/HapcanRelay.h
+++ b/SubModules/HapcanRelay/HapcanRelay.h
@@ -4,7 +4,7 @@
 #define _HAPCANRELAY_h
 
 #include "arduino.h"
-#include "../Onixarts_Hapcanuino/HapcanDevice.h"
+#include "HapcanDevice.h"
 #include <OnixartsIO.h>
 
 using namespace Onixarts::HomeAutomationCore;
@@ -36,10 +36,10 @@ namespace Onixarts
 						Hapcan::HapcanDevice& m_device;
 					public:
 						Module(Hapcan::HapcanDevice& device, byte channel, byte outputPin, byte instructionShift)
-							: Hapcan::SubModuleBase(instructionShift)
-							, IO::DigitalOutput(outputPin)
+							: IO::DigitalOutput(outputPin)
+							, Hapcan::SubModuleBase(instructionShift)
 							, m_channel(channel)
-							, m_device(device) 
+							, m_device(device)
 						{}
 
 						void OnStateChanged()


### PR DESCRIPTION
1. Kosmetyczna zmiana kolejności inicjalizacji parametrów, żeby uniknąć ostrzeżenia.
2. Usunięcie ścieżki względnej do HapcanDevice.h. Niech ścieżkami zarządza IDE.